### PR TITLE
Adding a server argument to the Client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API
 =====
 
     wpipe.Server(name, mode, *, maxclients = 5, maxmessagesz = 4096, maxtime = 100):
-    wpipe.Client(name, mode, *, maxmessagesz = 4096)
+    wpipe.Client(name, mode, *, maxmessagesz = 4096, server = '.')
 
 
 

--- a/wpipe.py
+++ b/wpipe.py
@@ -180,12 +180,13 @@ class ServerClient:
         hk32['CloseHandle'](ctypes_handle(self.handle))
 
 class Client(Base):
-    def __init__(self, name, mode, *, maxmessagesz = 4096):
+    def __init__(self, name, mode, *, maxmessagesz = 4096, server = '.'):
         self.mode = mode
         self.maxmessagesz = maxmessagesz
         self.name = name
+        self.server = server
         self.handle = hk32['CreateFileA'](
-            ctypes.c_char_p(b'\\\\.\\pipe\\' + bytes(name, 'utf8')),
+            ctypes.c_char_p(b'\\\\'+server+'\\pipe\\' + bytes(name, 'utf8')),
             ctypes.c_uint(GENERIC_READ | GENERIC_WRITE),
             0,                      # no sharing
             0,                      # default security
@@ -236,6 +237,8 @@ class Client(Base):
 
     def read(self):
         return self.client.read()
+
+
 
     def write(self, message):
         if not self.alive:

--- a/wpipe.py
+++ b/wpipe.py
@@ -186,7 +186,7 @@ class Client(Base):
         self.name = name
         self.server = server
         self.handle = hk32['CreateFileA'](
-            ctypes.c_char_p(b'\\\\'+server+'\\pipe\\' + bytes(name, 'utf8')),
+            ctypes.c_char_p(b'\\\\'+bytes(server, 'utf-8')+'\\pipe\\' + bytes(name, 'utf8')),
             ctypes.c_uint(GENERIC_READ | GENERIC_WRITE),
             0,                      # no sharing
             0,                      # default security


### PR DESCRIPTION
As proposed in issue #5 I added a named argument `server` to the Client constructor in order to change the default pipe path from `\\.\pipe\PIPE_NAME` to `\\SERVER_NAME_OR_IP\pipe\PIPE_NAME`.
However this is not tested yet but is considered to be a save addition.